### PR TITLE
fix: use ImportError for import fallback and 'is None' per PEP 8

### DIFF
--- a/bak/wan/utils/prompt_extend.py
+++ b/bak/wan/utils/prompt_extend.py
@@ -306,7 +306,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except ImportError:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28

--- a/data/lerobot/lerobot_dataset.py
+++ b/data/lerobot/lerobot_dataset.py
@@ -221,7 +221,7 @@ class LeRobotMotusDataset(data.Dataset):
 
             self.episode_ids = all_ep_ids
         elif self.task_mode == "multi":
-            if self.task_name == None:
+            if self.task_name is None:
                 self.repo_ids = [task_name for task_name in os.listdir(self.root) if os.path.isdir(os.path.join(self.root, task_name))]
             elif isinstance(self.task_name, list):
                 self.repo_ids = self.task_name

--- a/inference/real_world/Motus/bak/wan/utils/prompt_extend.py
+++ b/inference/real_world/Motus/bak/wan/utils/prompt_extend.py
@@ -306,7 +306,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except ImportError:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28

--- a/inference/robotwin/Motus/bak/wan/utils/prompt_extend.py
+++ b/inference/robotwin/Motus/bak/wan/utils/prompt_extend.py
@@ -306,7 +306,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except ImportError:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28


### PR DESCRIPTION
- `prompt_extend.py` (3 copies): bare `except:` → `except ImportError:` for relative import fallback
- `lerobot_dataset.py`: `== None` → `is None` (PEP 8 E711)